### PR TITLE
Update docs to only build ios libraries in carthage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ rustup target add armv7-apple-ios
     ```sh
 git submodule update --init --recursive
 brew install automake autoconf libtool gettext carthage
-carthage build
+carthage build --platform iOS
 ```
 
 3. iCepa should now build normally from Xcode. If it does not, please [file an issue](https://github.com/iCepa/iCepa/issues/new)! iCepa does not work in the iOS Simulator.


### PR DESCRIPTION
Hi, I've update the readme to use:

`    git push --set-upstream origin carthage-ios-only`

On carthage so only the iOS libraries are built.